### PR TITLE
Fix ESM import paths by adding .js extension to local imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
   ListToolsRequestSchema,
   McpError,
 } from "@modelcontextprotocol/sdk/types.js";
-import { ProjectManagementService } from "./services/ProjectManagementService";
+import { ProjectManagementService } from "./services/ProjectManagementService.js";
 
 function getRequiredEnvVar(name: string): string {
   const value = process.env[name];

--- a/src/infrastructure/github/GitHubRepositoryFactory.ts
+++ b/src/infrastructure/github/GitHubRepositoryFactory.ts
@@ -1,8 +1,8 @@
-import { GitHubConfig } from "./GitHubConfig";
-import { GitHubIssueRepository } from "./repositories/GitHubIssueRepository";
-import { GitHubMilestoneRepository } from "./repositories/GitHubMilestoneRepository";
-import { GitHubProjectRepository } from "./repositories/GitHubProjectRepository";
-import { GitHubSprintRepository } from "./repositories/GitHubSprintRepository";
+import { GitHubConfig } from "./GitHubConfig.js";
+import { GitHubIssueRepository } from "./repositories/GitHubIssueRepository.js";
+import { GitHubMilestoneRepository } from "./repositories/GitHubMilestoneRepository.js";
+import { GitHubProjectRepository } from "./repositories/GitHubProjectRepository.js";
+import { GitHubSprintRepository } from "./repositories/GitHubSprintRepository.js";
 
 export class GitHubRepositoryFactory {
   private static instance: GitHubRepositoryFactory;

--- a/src/services/ProjectManagementService.ts
+++ b/src/services/ProjectManagementService.ts
@@ -7,7 +7,7 @@ import {
   Sprint,
   SprintId,
 } from "../domain/types";
-import { GitHubRepositoryFactory } from "../infrastructure/github/GitHubRepositoryFactory";
+import { GitHubRepositoryFactory } from "../infrastructure/github/GitHubRepositoryFactory.js";
 
 export class ProjectManagementService {
   private factory: GitHubRepositoryFactory;


### PR DESCRIPTION
This PR resolves ESM import errors by adding the required .js extension to all local module imports. Since the project is configured as an ES module (type: module in package.json), explicit file extensions are necessary for local imports in the compiled JavaScript code.
This fixes the runtime error: ERR_MODULE_NOT_FOUND when running the built application.
Three files were modified to add the missing .js extensions:

- src/index.ts
- src/infrastructure/github/GitHubRepositoryFactory.ts
- src/services/ProjectManagementService.ts

Resolves [#1](https://github.com/kunwarVivek/mcp-github-project-manager/issues/1)